### PR TITLE
Add dockerfile to run website locally

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,6 +44,29 @@ build_host_release:
     - make release
     - "[ -d dist ] && echo 'dist directory found which is expected after make'"
 
+# Build dockerfilelint.com with the development profile using docker
+build_development_image:
+  stage: build
+  script:
+    - *log_into_docker
+    - docker build --pull -t $COMMIT_DEVELOPMENT_IMAGE .
+    - docker push $COMMIT_DEVELOPMENT_IMAGE
+
+# Test our docker image and verify that the container runs and anything supposed to be installed is
+test_development_image:
+  stage: test
+  script:
+    - apk add --no-cache curl && rm -rf /var/cache/apk/*
+    - *log_into_docker
+    - docker pull $COMMIT_DEVELOPMENT_IMAGE
+    - docker run -i $COMMIT_DEVELOPMENT_IMAGE /bin/sh -c 'grunt -V'
+    - docker run -i $COMMIT_DEVELOPMENT_IMAGE /bin/sh -c 'node -v'
+    - docker run -i $COMMIT_DEVELOPMENT_IMAGE /bin/sh -c 'npm -v'
+    - docker run -id -p 5000:5000 $COMMIT_DEVELOPMENT_IMAGE
+    # Verify the container is up
+    - "sleep 30 && docker ps"
+    - curl 172.17.0.3:5000
+
 # Lint our Dockerfile
 lint_dockerfile:
   image: theyorkshiredev/dockerfile-linter:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,15 @@
-FROM nginx:1.9.10
-COPY dist /usr/share/nginx/html
+FROM node:9.3.0
+
+COPY . /opt/dockerfilelint.com
+
+WORKDIR /opt/dockerfilelint.com
+
+RUN npm install -g grunt-cli babel
+
+RUN make deps
+
+RUN make build
+
+EXPOSE 5000
+
+CMD ["make", "run"]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ To build and run locally you will need the following installed:
 * Grunt & Grunt-Cli
 * Babel
 
+Alternatively, if you have docker installed build and run within a container (see below).
+
 ## Installation
 
 On Ubuntu:
@@ -27,7 +29,9 @@ npm install
 
 ## Build & Run
 
-You can choose to build and run the website on your host machine providing you have installed all the prerequisites (you will likely have most installed).
+You can choose to build and run the website on your host machine providing you have installed all the prerequisites (you will likely have most installed). Or, you can build using docker and run the image to serve the website.
+
+**Note**: building through docker does mean you cannot take use of the hot module replacement and you will need to rebuild the image to see any code changes take affect.
 
 ### Host Machine
 
@@ -36,6 +40,18 @@ You can choose to build and run the website on your host machine providing you h
 - `make run`
 
 The frontend will then be hosted at `http://127.0.0.1:5000/`
+
+### Docker
+
+#### Build Docker Image
+```bash
+docker build -t dockerfilelint.com .
+```
+
+#### Run Container
+```bash
+docker run -it --name dockerfilelint.com -p 5000:5000 dockerfilelint.com
+```
 
 ## Contributions
 


### PR DESCRIPTION
Update the existing dockerfile to allow building the website locally without the need for dependencies on the host machine.

Fixes #3 